### PR TITLE
Refactor `Bolt` to use default move operations

### DIFF
--- a/bolt/include/bolt.h
+++ b/bolt/include/bolt.h
@@ -9,7 +9,7 @@ class Bolt {
  public:
   Bolt();
   Bolt(Bolt &&other);
-  Bolt operator=(Bolt &&other);
+  Bolt & operator=(Bolt &&other);
   ~Bolt();
 
   void run();

--- a/bolt/src/bolt.cpp
+++ b/bolt/src/bolt.cpp
@@ -14,15 +14,8 @@ Bolt::Bolt()
     : pImpl(std::make_unique<BoltImpl>(
           HttpConnectionHandlerFactory::getHttpConnectionHandler())) {}
 
-Bolt::Bolt(Bolt &&other) : pImpl(std::move(other.pImpl)) {}
-
-Bolt Bolt::operator=(Bolt &&other) {
-  if (this != &other) {
-    pImpl = std::move(other.pImpl);
-  }
-  return std::move(*this);
-}
-
+Bolt::Bolt(Bolt &&other) = default;
+Bolt & Bolt::operator=(Bolt &&other) = default;
 Bolt::~Bolt() = default;
 
 void Bolt::run() { pImpl->run(); }


### PR DESCRIPTION
The default move operations do the correct thing here because of the
usage of std::unique_ptr.